### PR TITLE
CleanupTorrents.py fix for sonarrv3

### DIFF
--- a/roles/scripts/files/TorrentCleanup.py
+++ b/roles/scripts/files/TorrentCleanup.py
@@ -104,6 +104,8 @@ log = logging.getLogger("TorrentCleanup")
 if len(sys.argv) <= 1:
     log.error("You must specify an argument of either sonarr/radarr/lidarr.")
     sys.exit(0)
+elif 'Sonarr_EvenType_Test':
+    sys.exit(0)
 elif 'sonarr' in sys.argv[1].lower():
     sourceFile = os.environ.get('sonarr_episodefile_sourcepath')
     sourceFolder = os.environ.get('sonarr_episodefile_sourcefolder')


### PR DESCRIPTION
Added a few lines to change so that this script works with sonarrv3. All that needed changing was something to handle the new test feature.

For future reference the script must be able to hand sonarr event type test properly ie exit with code 0 as I have done here.